### PR TITLE
Build docker image using buildpacks

### DIFF
--- a/lab-reports/Dockerfile
+++ b/lab-reports/Dockerfile
@@ -32,9 +32,11 @@ COPY --from=build /app/target/lab-reports-0.0.1-SNAPSHOT.jar .
 CMD ["java", "-jar", "lab-reports-0.0.1-SNAPSHOT.jar"]
 #CMD ["mvn", "mvn spring-boot:run"]
 
-#command to create image
+# command to create image
 # docker build . -t vinodg8073/lab_report:v1
+# mvn spring-boot:build-image
 
 # run the containers
-#docker run -d --name laboratoryDB -e POSTGRES_DB=laboratoryDB -e POSTGRES_USER=root  -e POSTGRES_PASSWORD=admin -p 5432:5432 postgres:latest
-#docker run -d --name lab-reports -p 8080:8080 vinodg8073/lab_report:v1
+# docker run -d --name laboratoryDB -e POSTGRES_DB=laboratoryDB -e POSTGRES_USER=root  -e POSTGRES_PASSWORD=admin -p 5432:5432 postgres:latest
+# docker run -d --name lab-reports -p 8080:8080 vinodg8073/lab_report:v1
+# docker run -d --name lab-user-management -p 8081:8081 lab-user-management:0.0.1-SNAPSHOT

--- a/lab-user-management/pom.xml
+++ b/lab-user-management/pom.xml
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.2.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.lab.user.management</groupId>
 	<artifactId>lab-user-management</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>lab-user-management</name>
+	<packaging>jar</packaging>
 	<description>User service which can be accessed/edited only by admins roles</description>
 	<properties>
 		<java.version>17</java.version>
+		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -25,10 +28,8 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<!--<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-rest</artifactId>
-		</dependency>   -->
+		<!--<dependency> <groupId>org.springframework.boot</groupId> <artifactId>spring-boot-starter-data-rest</artifactId> 
+			</dependency> -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
@@ -51,7 +52,7 @@
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
-			<version>1.6.0.Beta1</version>
+			<version>${org.mapstruct.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
@@ -84,11 +85,23 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
+					<image>
+						<name>vinodg8073/${project.artifactId}:v1</name>
+					</image>
+
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<encoding>${project.build.sourceEncoding}</encoding>
 					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
 						<path>
 							<groupId>org.mapstruct</groupId>
 							<artifactId>mapstruct-processor</artifactId>
-							<version>1.6.0.Beta1</version>
+							<version>${org.mapstruct.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>


### PR DESCRIPTION
Advantage : 
See image size of lab-reports and lab-user-management. Even though lab-user-management has more code than lab-reports, image size is smaller than lab-report image.
![image](https://github.com/vinodg8073/micro-services/assets/98164064/07f1d8e1-4358-4ae6-91e3-57ff14e6bc9c)

Commands : 
mvn spring-boot:build-image  
docker run -d --name lab-user-management -p 8081:8081 lab-user-management:0.0.1-SNAPSHOT