### PR TITLE
Encrypt Sensitive properties

### DIFF
--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -18,3 +18,6 @@ spring:
 #          force-pull: true  #(at startup pulls latest changes when already cloned config has some changes made )
 server:
   port: 8091
+    
+encrypt:
+  key: 373HDS3828SHS7 # Any complex value || at real time configured from external

--- a/config-server/src/main/resources/config/lab-user-management-prod.yml
+++ b/config-server/src/main/resources/config/lab-user-management-prod.yml
@@ -1,5 +1,5 @@
 code-owner:
   name: vinod g
-  email: lab.support@gmail.com
+  email: "{cipher}140f7079c7e29eb3e1bf63a86f907cae9bbc680e023881498763d9b6c4149c1329f9803fab87f886474a90695a935e0f"  # SCC assumes after {cipher} is an encripted value
   contact:
     - 1234567890


### PR DESCRIPTION
Advantage:
Cannot read the property when the key is configured externally

Encrypt :
![image](https://github.com/vinodg8073/micro-services/assets/98164064/8661c536-375f-4022-89be-6cfdede7c551)

Decrypt:
![image](https://github.com/vinodg8073/micro-services/assets/98164064/9f6a8971-9768-4936-b929-7b65f1fed1eb)

Output:
![image](https://github.com/vinodg8073/micro-services/assets/98164064/7b9c1bcb-64df-49a1-ba80-c22bb8398e38)

