### PR TITLE
Refresh configuration property when there is change using actuator

### DIFF
--- a/lab-user-management/src/main/resources/application.yml
+++ b/lab-user-management/src/main/resources/application.yml
@@ -41,3 +41,9 @@ code-owner:
   contact:
     - xxxxxx9494
     - xxxxxx1234   
+
+#management:  # by default actuator doesn't expose
+#  endpoints:
+#    web:
+#      exposure:
+#        include: "*"     #Enable & expose management related api paths(actuator api's)


### PR DESCRIPTION
When there is a change made on configuration property inside the github/File and Config server is running, The Microservice loads the configs at the startup so to refresh the properties without redeploying microservice we need actuator/refresh api path. 
![image](https://github.com/vinodg8073/micro-services/assets/98164064/a47e216e-b2ef-45d4-b781-211d1bdda9c0)

Then when we hit our user management api it loads the updated value.

**Disadvantage:**
When we have more than 100 Microservices / instances. we need o refresh against all the instance.