### PR TITLE
Refresh config properties using SCB and SCCM

### DIFF
--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.3.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.lab.configserver</groupId>
 	<artifactId>config-server</artifactId>
@@ -26,7 +27,15 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-config-server</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-bus-amqp</artifactId>
+		</dependency>
+		<!-- only inside ConfigServer to hit /monitor api(by sccs) -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-config-monitor</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -16,8 +16,22 @@ spring:
 #          timeout: 5
 #          clone-on-start: true #clone github repo at startup (if not provided clones at first request disadvantage: sometimes CS can be started but couldn't load the configs')
 #          force-pull: true  #(at startup pulls latest changes when already cloned config has some changes made )
+
+  rabbitmq:
+    host: "localhost"
+    port: 5672
+    username: "guest"
+    password: "guest"
+    
+# To hit /monitor api (CS uses Spring cloud bus) || create github webhook to hit the api when changes made on config properties repository
+management:  
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+         
 server:
   port: 8091
     
-encrypt:
+encrypt:     #Can encript, decrypt using same application based on below key using /encrypt , /decrypt endpoint
   key: 373HDS3828SHS7 # Any complex value || at real time configured from external

--- a/lab-user-management/pom.xml
+++ b/lab-user-management/pom.xml
@@ -39,7 +39,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -68,6 +67,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-bus-amqp</artifactId>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/lab-user-management/src/main/resources/application.yml
+++ b/lab-user-management/src/main/resources/application.yml
@@ -24,6 +24,13 @@ spring:
   profiles:
     active: "prod"  # or pass from external config
 
+# MQ connection same for other microservices. By default it has below values no need to configure   
+  rabbitmq:
+    host: "localhost"
+    port: 5672
+    username: "guest"
+    password: "guest"
+
 ### Read configs from Spring profiles           
 #  config:                    # commented out to use SCCS to read the configurations
 #    import:


### PR DESCRIPTION
Spring cloud bus:

- add dependency spring-cloud-starter-bus-amqp in both config server and client services (MS)
- run rabbit mq container docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3.13-management
- enable busrefresh api path
- provide details of rabitmq connection in all individual ms
- start all MS and invoke /actuator/busrefresh api for any one of the instance  and changes will be reflected in all other instances which are connected to same MQ server.

Spring cloud config monitor:

- add dependency spring-cloud-config-monitor only in config server(CS)
- enable refresh api path inside CS
- provide details of rabitmq connection inside CS
- create a github webhook when using configuration repository to hit /monitor api (use hookdeck to connect for local machine)

![image](https://github.com/vinodg8073/micro-services/assets/98164064/944c70f6-27ff-4f85-bbb3-9bb5fcf24afb)
Logs in hookdeck login cli
![image](https://github.com/vinodg8073/micro-services/assets/98164064/b99fb62b-aed6-4a45-afb8-69461979d707)
