### PR TITLE
Liveness and Readiness probe on ConfigServer

### DIFF
--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -29,7 +29,15 @@ management:
     web:
       exposure:
         include: "*"
-         
+  health:  # tells actuator to enable health related information 
+    readinessstate:
+      enabled: true
+    livenessstate:
+      enabled: true
+  endpoint:  # enable the endpoint to read the health related information 
+    health:
+      probes:
+        enabled: true       
 server:
   port: 8091
     


### PR DESCRIPTION
Liveness : Signals container is alive or dead
Readiness: Check if ready to accept the request

Should have actuator dependency.

endpoints:

- actuator/health
- actuator/health/liveness
- actuator/health/readiness

Down when rabbit MQ container is stopped (not able to connect by CS)
![image](https://github.com/vinodg8073/micro-services/assets/98164064/dfd6e890-bdaa-4584-b595-05fc367aa933)
![image](https://github.com/vinodg8073/micro-services/assets/98164064/21d745e8-61fc-4f85-bf69-6468f9314858)
![image](https://github.com/vinodg8073/micro-services/assets/98164064/9d4e68fa-a663-45a5-bd0a-1cbd7846a143)

Up when connected 

![image](https://github.com/vinodg8073/micro-services/assets/98164064/bfebcffe-51a7-4aa4-b30a-fa503aba0857)
![image](https://github.com/vinodg8073/micro-services/assets/98164064/8a3e6962-10cb-4aca-92df-668fad7cbf54)
According to SCCS rabitmq connection is an optional setting So readiness is up