### PR TITLE
Rate Limiter on Gateway and Microservice

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -63,6 +63,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/gateway-server/src/main/resources/application.yml
+++ b/gateway-server/src/main/resources/application.yml
@@ -13,7 +13,12 @@ spring:
 #      httpclient:  #applicable for all paths except circuit breaker configued [Can also specify to path for route in CB filter configs]
 #        connect-timeout: 1000  #Time take by gateway server to get connection w/ microservice
 #        response-timeout: 3s #Max time to receive response from microservice
-        
+  data:
+    redis:
+      connect-timeout: 2s
+      host: localhost
+      port: 6379
+      timeout: 1s     
 management:  
   endpoints:
     web:

--- a/lab-reports/Dockerfile
+++ b/lab-reports/Dockerfile
@@ -41,3 +41,4 @@ CMD ["java", "-jar", "lab-reports-0.0.1-SNAPSHOT.jar"]
 # docker run -d --name lab-reports -p 8080:8080 vinodg8073/lab_report:v1
 # docker run -d --name lab-user-management -p 8081:8081 lab-user-management:0.0.1-SNAPSHOT
 # docker run -it --rm --name rabbitmq -d -p 5672:5672 -p 15672:15672 rabbitmq:3.13-management
+# docker run --name laboratory -d -p 6379:6379 redis

--- a/lab-user-management/src/main/java/com/lab/user/management/controller/UserController.java
+++ b/lab-user-management/src/main/java/com/lab/user/management/controller/UserController.java
@@ -22,6 +22,7 @@ import com.lab.user.management.dto.UserDetailsDTO;
 import com.lab.user.management.entity.User;
 import com.lab.user.management.service.UserService;
 
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -103,11 +104,16 @@ public class UserController {
 		return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Could not save. check if the user already present");
 	}
 	
+	@RateLimiter(name="buildVersion", fallbackMethod = "builVersionFallBack")
 	@GetMapping("/build-version")
 	@Operation(summary = "Fetch build version", description = "API to fetch build version from internal (application.yml) configurations")
 	@ApiResponses({ @ApiResponse(responseCode = "200", description = "HTTP Status OK") })
 	public ResponseEntity<String> getBuildVersion(){
 		return ResponseEntity.status(HttpStatus.OK).body("Build-Version : " +buildVersion);
+	}
+	
+	public ResponseEntity<String> builVersionFallBack(){
+		return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body("Please try after some time.");
 	}
 	
 	@Retry(name = "getJavaHomePath", fallbackMethod = "getJavaHomePathFallBack")

--- a/lab-user-management/src/main/java/com/lab/user/management/controller/UserController.java
+++ b/lab-user-management/src/main/java/com/lab/user/management/controller/UserController.java
@@ -112,7 +112,7 @@ public class UserController {
 		return ResponseEntity.status(HttpStatus.OK).body("Build-Version : " +buildVersion);
 	}
 	
-	public ResponseEntity<String> builVersionFallBack(){
+	public ResponseEntity<String> builVersionFallBack(Throwable throwable){
 		return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body("Please try after some time.");
 	}
 	

--- a/lab-user-management/src/main/resources/application.yml
+++ b/lab-user-management/src/main/resources/application.yml
@@ -79,4 +79,10 @@ resilience4j.retry:
       retryExceptions:  #Retry happens only for these excpetions and ignored configs will automatically be removed
         - java.util.concurrent.TimeoutException
         - java.lang.NullPointerException
-        
+
+resilience4j.ratelimiter:
+  configs:
+    default:
+      timeoutDuration: 1000
+      limitRefreshPeriod: 5000   # for every 5 seconds accepts only 1 request. If 2nd request is made within that and timeout happens default error thrown or fallback mechanism works
+      limitForPeriod: 1        


### PR DESCRIPTION
**Rate limiter on gateway server:**

Load test using apache benchmark : (configured 1 request per second using keyresolver criteria as user_id and RateLimter replenishRate =1, burstCapacity =1, requestedToken = 1)
![image](https://github.com/user-attachments/assets/986a7cad-d774-4097-b679-4dbf5bb4cd92)
![image](https://github.com/user-attachments/assets/9256ac2c-f34e-4bbc-8ceb-abda51294797)

**Rate limiter on microservice**

![image](https://github.com/user-attachments/assets/75c91781-4407-4337-bd9a-96cf560202e9)
![image](https://github.com/user-attachments/assets/8b48afb5-abe8-4dc9-a89f-2ae47975b361)
![image](https://github.com/user-attachments/assets/1728b4d9-8ccc-4a67-bbdf-5ad5b7544d3b)
without fallback 
![image](https://github.com/user-attachments/assets/b0a9472d-6e60-4bf0-9b1c-bfb46ee47e21)

With Fallback : 
![image](https://github.com/user-attachments/assets/2ee86e3c-a80c-4469-a124-182dbf8e43e3)
![image](https://github.com/user-attachments/assets/7f9e5ece-7e66-4f05-9b2f-7761e95437dc)

